### PR TITLE
Fix infinite scroll when the initial page is a post/page

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -109,16 +109,18 @@
         });
     </script>
 
-
-    {{#if pagination.pages}}
     <script>
         // maxPages is a global variable that is needed to determine
         // if we need to load more pages for the infinitescroll, or if
         // we reached the last page already.
-        var maxPages = parseInt('{{pagination.pages}}');
+        {{#if pagination.pages}}
+            var maxPages = parseInt('{{pagination.pages}}');
+        {{else}}
+            var getAllPosts = {{#get "tags" limit="all" include="count.posts"}}{{#foreach tags}}{{count.posts}}{{^if @last}}+{{/if}}{{/foreach}}{{/get}};
+            var maxPages = Math.ceil(getAllPosts/{{@config.posts_per_page}});
+        {{/if}}
     </script>
     <script src="{{asset "built/infinitescroll.js"}}"></script>
-    {{/if}}
 
     {{!-- The #block helper will pull in data from the #contentFor other template files. In this case, there's some JavaScript which we only want to use in post.hbs, but it needs to be included down here, after jQuery has already loaded. --}}
     {{{block "scripts"}}}

--- a/default.hbs
+++ b/default.hbs
@@ -116,7 +116,7 @@
         {{#if pagination.pages}}
             var maxPages = parseInt('{{pagination.pages}}');
         {{else}}
-            var getAllPosts = {{#get "tags" limit="all" include="count.posts"}}{{#foreach tags}}{{count.posts}}{{^if @last}}+{{/if}}{{/foreach}}{{/get}};
+            var getAllPosts = {{#get "authors" limit="all" include="count.posts"}}{{#foreach authors}}{{count.posts}}{{^if @last}}+{{/if}}{{/foreach}}{{/get}};
             var maxPages = Math.ceil(getAllPosts/{{@config.posts_per_page}});
         {{/if}}
     </script>


### PR DESCRIPTION
This pull request fixes issue #7 .

I coudn't find a better way to get the `maxPages` js variable when `pagination.pages` is not available. First I thought that I can `get` all posts but the was a huge request and might take a while. Then I used `tags` and realised that this design is better suited for a small number of authors. To fix, I get all `authors` and sum the total number of posts for each one.