### PR TITLE
Replace {{#each}} with {{#foreach}}

### DIFF
--- a/error.hbs
+++ b/error.hbs
@@ -11,16 +11,16 @@
     <section class="error-stack">
         <h3>Theme errors</h3>
         <ul class="error-stack-list">
-            {{#each errorDetails}}
+            {{#foreach errorDetails}}
             <li>
                 <em class="error-stack-function">{{{rule}}}</em>
 
-                {{#each failures}}
+                {{#foreach failures}}
                 <p><span class="error-stack-file">Ref: {{ref}}</span></p>
                 <p><span class="error-stack-file">Message: {{message}}</span></p>
-                {{/each}}
+                {{/foreach}}
             </li>
-            {{/each}}
+            {{/foreach}}
         </ul>
     </section>
 </div>


### PR DESCRIPTION
The {{#foreach}} helper is context-aware and should always be used instead of Handlebars {{#each}} when working with Ghost themes.