### PR TITLE
Fix for uncentered post images

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -550,6 +550,7 @@ body {
     margin-left: calc(50% - 50vw);
     margin-right: calc(50% - 50vw);
     transform: translateX(calc(50vw - 50%));
+    text-align: center;
 }
 
 .post-content-body {


### PR DESCRIPTION
Found the culprit for the post images that are not centered on my adaptief.de website with this theme. I thought I'd let you know and share the fix.