### PR TITLE
fixed: {{lang}} and {{foreach}}

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{lang}}">
+<html lang="{{@site.lang}}">
 <head>
 
     {{!-- Document Settings --}}

--- a/error.hbs
+++ b/error.hbs
@@ -11,16 +11,16 @@
     <section class="error-stack">
         <h3>Theme errors</h3>
         <ul class="error-stack-list">
-            {{#each errorDetails}}
+            {{#foreach errorDetails}}
             <li>
                 <em class="error-stack-function">{{{rule}}}</em>
 
-                {{#each failures}}
+                {{#foreach failures}}
                 <p><span class="error-stack-file">Ref: {{ref}}</span></p>
                 <p><span class="error-stack-file">Message: {{message}}</span></p>
-                {{/each}}
+                {{/foreach}}
             </li>
-            {{/each}}
+            {{/foreach}}
         </ul>
     </section>
 </div>


### PR DESCRIPTION
Fixed two warnings

1. change `{{lang}}` to `{{@site.lang}}` on `default.hbs`

2. change `{#each}}` to `{{#foreach}}` on page `error.hbs`

![warnings](https://user-images.githubusercontent.com/535675/64957379-68327080-d8bf-11e9-9e2d-2ab2e4660a3d.png)
