### PR TITLE
Update error.hbs to be compatible with Ghost 3.0

### DIFF
--- a/error.hbs
+++ b/error.hbs
@@ -1,7 +1,7 @@
 {{!< default}}
 
 <header class="page-head error-head">
-    <h1 class="page-head-title">{{code}}</h1>
+    <h1 class="page-head-title">{{statusCode}}</h1>
     <p class="page-head-description">{{message}}</p>
     <a class="error-link" href="{{@site.url}}">Go to the front page →</a>
 </header>


### PR DESCRIPTION
As Ghost v3.0 said : 
The usage of {{error.code}} is deprecated and should be replaced with {{error.statusCode}}.
When in error context, e. g. in the error.hbs template, replace {{code}} with {{statusCode}}.
Find more information about the error.hbs template here (https://ghost.org/docs/api/handlebars-themes/structure/#errorhbs).