### PR TITLE
Remove jQuery

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -93,11 +93,6 @@
 
     <script src="{{asset "built/swup.js"}}" data-swup-ignore-script></script>
     <script src="{{asset "built/infinitescroll.js"}}" data-swup-ignore-script></script>
-    <script
-        src="https://code.jquery.com/jquery-3.2.1.min.js"
-        integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-        crossorigin="anonymous">
-    </script>
 
     <div id="swup">
         {{!-- The #block helper will pull in data from the #contentFor other template files. In this case, there's some JavaScript which we only want to use in post.hbs, but it needs to be included down here, after jQuery has already loaded. --}}
@@ -109,11 +104,11 @@
 
     {{!-- Handle swup content replacement --}}
     <script data-swup-ignore-script>
-        $(document).ready(function () {
-            // Mobile Menu Trigger
-            $('.nav-burger').click(function () {
-                $('body').toggleClass('site-head-open');
-            });
+        document.addEventListener("DOMContentLoaded", function(event) {
+             // Mobile Menu Trigger
+             document.getElementsByClassName("nav-burger")[0].onclick = function() {
+                document.body.classList.toggle("site-head-open");
+             };
         });
 
         // Initiate Swup transitions
@@ -123,7 +118,7 @@
         document.addEventListener('swup:contentReplaced', event => {
             window.scrollTo(0, 0);
             initInfiniteScroll(window, document);
-            $('body').removeClass('site-head-open');
+            document.body.classList.remove("site-head-open");
         });
     </script>
 


### PR DESCRIPTION
I was analyzing performance of my Ghost blog w/ this theme using [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) and one of the issues immideately found was jQuery:

- it's big
- it consumes CPU time on initialization

Turned out, it's only used in very few places in `default.hbs` and it was easy to replace with native functions even for me (I don't work with web frontend stack) 🙃

Before:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/967132/141646008-1ced0515-c3bb-4f04-b6b2-ec565ed5b260.png">

<img width="750" alt="image" src="https://user-images.githubusercontent.com/967132/141646023-0777867e-9bf0-4420-8489-0d9829dfce50.png">

After:

<img width="738" alt="image" src="https://user-images.githubusercontent.com/967132/141646201-b16f33a2-61fc-4ac7-b5b0-6469e0e38846.png">
