### PR TITLE
Workaround to fix backround color.

### DIFF
--- a/assets/css/vars.css
+++ b/assets/css/vars.css
@@ -7,6 +7,7 @@
     --color-base: #131313;
     --color-border: #ddd;
     --color-bg: #f8f8f8;
+    --color-white: #f8f8f8;
 
     /* Fonts */
     --font-sans: Mulish, sans-serif;


### PR DESCRIPTION
I don't know yet why, but color-bg does not work. So i added color-white instead, which works well so far. 
Also what happened with the transition effect it had in the past?